### PR TITLE
allow line/offset positioning

### DIFF
--- a/lib/vim-buffer.js
+++ b/lib/vim-buffer.js
@@ -38,11 +38,18 @@ VimBuffer.prototype._cleanup = function () {
 	}
 };
 
-VimBuffer.prototype.addAnno = function (type, offset) {
+VimBuffer.prototype.addAnno = function (type, line, col) {
 	var typeNum = this.annoTypeNums[type.id] || this.defineAnnoType(type);
 	var serNum = this.maxAnnoSerNum++;
-	this._sendCommand("addAnno", [serNum, typeNum, offset, 1]);
+  var pos = line; // offset if one argument
+  if (arguments.length == 3) // line and col set
+    pos = [line, col];
+	this._sendCommand("addAnno", [serNum, typeNum, pos]);
 	return serNum;
+};
+
+VimBuffer.prototype.showBaloon = function (text) {
+  this._sendCommand("showBaloon", text);
 };
 
 VimBuffer.prototype.close = function () {
@@ -100,12 +107,12 @@ VimBuffer.prototype.saveDone = function () {
 	this._sendCommand("saveDone");
 };
 
-VimBuffer.prototype.setDot = function fn(offset) {
-	if (fn.arguments.length == 2) {
-		// lnum/col
-		offset += "/" + fn.arguments[1];
+VimBuffer.prototype.setDot = function fn(line, col) {
+	var args = line;
+  if (arguments.length == 2) {
+    args = [[line, col]];
 	}
-	this._sendCommand("setDot", offset);
+	this._sendCommand("setDot", args);
 };
 
 VimBuffer.prototype.setFullName = function (pathname) {

--- a/lib/vim-buffer.js
+++ b/lib/vim-buffer.js
@@ -48,8 +48,8 @@ VimBuffer.prototype.addAnno = function (type, line, col) {
 	return serNum;
 };
 
-VimBuffer.prototype.showBaloon = function (text) {
-  this._sendCommand("showBaloon", text);
+VimBuffer.prototype.showBalloon = function (text) {
+  this._sendCommand("showBalloon", text);
 };
 
 VimBuffer.prototype.close = function () {

--- a/lib/vim-client.js
+++ b/lib/vim-client.js
@@ -145,6 +145,7 @@ function quoteArg(item) {
 	if (item == -Infinity) return "none"; // color sentinel
 	if (typeof item == "number") return item.toString();
 	if (typeof item == "boolean") return item ? "T" : "F";
+  if (Array.isArray(item) && item.length === 2) return item.map(quoteArg).join("/");
 	if (!item) return '""';
 	return '"' + (item.toString().
 		replace(backslashRe, '\\\\').

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vim-netbeans",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "A server for Vim clients using the NetBeans Protocol.",
   "author": "Charles Lehner",
   "license": "MIT",


### PR DESCRIPTION
There was no way to send, for example 10/10 as a parameter to setDot as it was wrapped in quotes. Added special argument type handling where array of length 2 is treated as val1 / val2 pair and serialised accordingly.
